### PR TITLE
added check for SysMain service

### DIFF
--- a/plugins/prefetch.pl
+++ b/plugins/prefetch.pl
@@ -3,7 +3,7 @@
 #   Access System hive file to get the Prefetch Parameters
 # 
 # Change history
-#   
+#   2016-05-06  Added check for SysMain service start method. James Habben
 #
 # References
 #   http://msdn.microsoft.com/en-us/library/bb499146(v=winembedded.5).aspx
@@ -19,6 +19,12 @@ my %config = (hive          => "SYSTEM",
               hasRefs       => 0,
               osmask        => 22,
               version       => 20120914);
+			  
+my %starts = (0x00 => "Boot Start",
+              0x01 => "System Start",
+              0x02 => "Auto Start",
+              0x03 => "Manual",
+              0x04 => "Disabled");
 
 sub getConfig{return %config}
 sub getShortDescr {
@@ -64,6 +70,24 @@ sub pluginmain {
 		else {
 			::rptMsg($pp_path." not found.");
 			::logMsg($pp_path." not found.");
+		}
+		
+		my $pfsvc_path = $ccs."\\services\\SysMain";
+		my $pfsvc;
+		if ($pfsvc = $root_key->get_subkey($pfsvc_path)) {
+			my $svc_start = $pfsvc->get_value("Start")->get_data();
+			if (exists $starts{$svc_start}) {
+				$svc_start = $starts{$svc_start};
+			}
+			::rptMsg("");
+			::rptMsg("Superfetch service runs both Superfetch and Prefetch functions. Shortname is SysMain.");
+			::rptMsg("SysMain Service    = ".$svc_start);
+
+			
+		}
+		else {
+			::rptMsg($pfsvc_path." not found.");
+			::logMsg($pfsvc_path." not found.");
 		}
 	}
 	else {

--- a/plugins/prefetch.pl
+++ b/plugins/prefetch.pl
@@ -18,7 +18,7 @@ my %config = (hive          => "SYSTEM",
               hasDescr      => 0,
               hasRefs       => 0,
               osmask        => 22,
-              version       => 20120914);
+              version       => 20160506);
 			  
 my %starts = (0x00 => "Boot Start",
               0x01 => "System Start",


### PR DESCRIPTION
I have found so many systems that have the prefetch parameters turned on, but the SysMain (Superfetch) service is set for manual start. This gives the false impression that prefetch is enabled, but there will be no .pf trace files unless the service is started.