### PR TITLE
Fixed missing variable declaration in defbrowser.pl

### DIFF
--- a/plugins/defbrowser.pl
+++ b/plugins/defbrowser.pl
@@ -56,7 +56,7 @@ sub pluginmain {
 	::rptMsg("");
 
 	$key_path = "Classes\\HTTP\\shell\\open\\command";
-	if ($key = $root_key->get_subkey($key_path)) {
+	if (my $key = $root_key->get_subkey($key_path)) {
 		::rptMsg("Default Browser Check #2");
 		::rptMsg($key_path);
 		::rptMsg("LastWrite Time ".gmtime($key->get_timestamp())." (UTC)");


### PR DESCRIPTION
Plugin fails to run because $key is only declared within the context of the previous 'if' statement (see error below). Declaring $key in the second 'if' statement fixes the issue.

Global symbol "$key" requires explicit package name at /usr/share/regripper/plugins/defbrowser.pl line 62.
Global symbol "$key" requires explicit package name at /usr/share/regripper/plugins/defbrowser.pl line 66.
Compilation failed in require at /usr/local/bin/rip.pl line 179.
