### PR TITLE
added checks to while loops that don't exit without substr results

### DIFF
--- a/plugins/appcompatcache.pl
+++ b/plugins/appcompatcache.pl
@@ -296,6 +296,7 @@ sub appWin8 {
 	
 	while($ofs < $len) {
 		my $tag = unpack("V",substr($data,$ofs,4));
+                last unless (defined $tag); 
 # 32-bit		
 		if ($tag == 0x73746f72) {
 			$jmp = unpack("V",substr($data,$ofs + 8,4));
@@ -340,6 +341,7 @@ sub appWin10 {
 	
 	while ($ofs < $len) {
 		$tag = substr($data,$ofs,4);
+                last unless (defined $tag); 
 		if ($tag eq "10ts") {
 			
 			$sz = unpack("V",substr($data,$ofs + 0x08,4));

--- a/plugins/appcompatcache_tln.pl
+++ b/plugins/appcompatcache_tln.pl
@@ -291,6 +291,7 @@ sub appWin8 {
 	
 	while($ofs < $len) {
 		my $tag = unpack("V",substr($data,$ofs,4));
+                last unless (defined $tag); 
 # 32-bit		
 		if ($tag == 0x73746f72) {
 			$jmp = unpack("V",substr($data,$ofs + 8,4));
@@ -335,6 +336,7 @@ sub appWin10 {
 	
 	while ($ofs < $len) {
 		$tag = substr($data,$ofs,4);
+                last unless (defined $tag); 
 		if ($tag eq "10ts") {
 			
 			$sz = unpack("V",substr($data,$ofs + 0x08,4));

--- a/plugins/arpcache.pl
+++ b/plugins/arpcache.pl
@@ -122,6 +122,7 @@ sub parsePath {
 		while($tag) {
 			$ofs += 2;
 			my $i = substr($data,$ofs,2);
+                        last unless (defined $i); 
 			if (unpack("v",$i) == 0) {
 				$tag = 0;
 			}

--- a/plugins/comdlg32.pl
+++ b/plugins/comdlg32.pl
@@ -386,6 +386,7 @@ sub parseShellItem {
 	while ($tag) {
 		my %item = ();
 		my $sz = unpack("v",substr($data,$cnt,2));
+                return %str unless (defined $sz); 
 		$tag = 0 if (($sz == 0) || ($cnt + $sz > $len));
 		
 		my $dat = substr($data,$cnt,$sz);
@@ -544,6 +545,7 @@ sub parseFolderEntry {
 	my $str = "";
 	while($tag) {
 		my $s = substr($data,$ofs_shortname + $cnt,1);
+                return %item unless (defined $s); 
 		if ($s =~ m/\x00/ && ((($cnt + 1) % 2) == 0)) {
 			$tag = 0;
 		}
@@ -559,7 +561,9 @@ sub parseFolderEntry {
 	$tag = 1;
 	$cnt = 0;
 	while ($tag) {
-		if (unpack("v",substr($data,$ofs + $cnt,2)) == 0xbeef) {
+                my $s = substr($data,$ofs + $cnt,2);
+                return %item unless (defined $s); 
+		if (unpack("v",$s) == 0xbeef) {
 			$tag = 0;
 		}
 		else {

--- a/plugins/itempos.pl
+++ b/plugins/itempos.pl
@@ -228,6 +228,7 @@ sub parseFolderItem {
 	my $str = "";
 	while($tag) {
 		my $s = substr($data,$ofs_shortname + $cnt,1);
+                return %item unless (defined $s); 
 		if ($s =~ m/\x00/ && ((($cnt + 1) % 2) == 0)) {
 			$tag = 0;
 		}
@@ -243,7 +244,9 @@ sub parseFolderItem {
 	$tag = 1;
 	$cnt = 0;
 	while ($tag) {
-		if (unpack("v",substr($data,$ofs + $cnt,2)) == 0xbeef) {
+                my $s = substr($data,$ofs + $cnt,2);
+                return %item unless (defined $s); 
+		if (unpack("v",$s) == 0xbeef) {
 			$tag = 0;
 		}
 		else {

--- a/plugins/shellbags.pl
+++ b/plugins/shellbags.pl
@@ -378,6 +378,7 @@ sub parseVariableEntry {
 	  	my $cnt = 0x10;
 	  	while($tag) {
 	  		my $sz = unpack("V",substr($stuff,$cnt,4));
+                        return %item unless (defined $sz); 
 	  		my $id = unpack("V",substr($stuff,$cnt + 4,4));
 #--------------------------------------------------------------
 # sub-segment types
@@ -421,6 +422,7 @@ sub parseVariableEntry {
 		my $t = 1;
 		while ($t) {
 			my $i = substr($data,$o,1);
+                        return %item unless (defined $i); 
 			if ($i =~ m/\x00/) {
 				$t = 0;
 			}
@@ -732,6 +734,7 @@ sub parseFolderEntry {
 	my $str = "";
 	while($tag) {
 		my $s = substr($data,$ofs_shortname + $cnt,1);
+                return %item unless (defined $s); 
 		if ($s =~ m/\x00/ && ((($cnt + 1) % 2) == 0)) {
 			$tag = 0;
 		}
@@ -747,7 +750,9 @@ sub parseFolderEntry {
 	$tag = 1;
 	$cnt = 0;
 	while ($tag) {
-		if (unpack("v",substr($data,$ofs + $cnt,2)) == 0xbeef) {
+                my $s = substr($data,$ofs + $cnt,2);
+                return %item unless (defined $s); 
+		if (unpack("v",$s) == 0xbeef) {
 			$tag = 0;
 		}
 		else {
@@ -850,7 +855,9 @@ sub parseFolderEntry2 {
 	my $tag = 1;
 
 	while ($tag) {
-		if (unpack("v",substr($data,$ofs,2)) == 0xbeef) {
+                my $s = substr($data,$ofs,2);
+                return %item unless (defined $s); 
+		if (unpack("v",$s) == 0xbeef) {
 			$tag = 0;
 		}
 		else {
@@ -951,6 +958,7 @@ sub shellItem0x52 {
 	
 	while ($tag) {
 		$d = substr($data,0x32 + $cnt,2);
+                return %item unless (defined $d); 
 		if (unpack("v",$d) == 0) {
 			$tag = 0;
 		}

--- a/plugins/shellbags_test.pl
+++ b/plugins/shellbags_test.pl
@@ -358,6 +358,7 @@ sub parseFolderItem {
 	my $str = "";
 	while($tag) {
 		my $s = substr($data,$ofs_shortname + $cnt,1);
+                return %item unless (defined $s); 
 		if ($s =~ m/\x00/ && ((($cnt + 1) % 2) == 0)) {
 			$tag = 0;
 		}
@@ -373,7 +374,9 @@ sub parseFolderItem {
 	$tag = 1;
 	$cnt = 0;
 	while ($tag) {
-		if (unpack("v",substr($data,$ofs + $cnt,2)) == 0xbeef) {
+                my $s = substr($data,$ofs + $cnt,2);
+                return %item unless (defined $s); 
+		if (unpack("v",$s) == 0xbeef) {
 			$tag = 0;
 		}
 		else {

--- a/plugins/shellbags_tln.pl
+++ b/plugins/shellbags_tln.pl
@@ -356,6 +356,7 @@ sub parseVariableEntry {
 	  	while($tag) {
 	  		my $sz = unpack("V",substr($stuff,$cnt,4));
 	  		my $id = unpack("V",substr($stuff,$cnt + 4,4));
+                        return %item unless (defined $sz); 
 #--------------------------------------------------------------
 # sub-segment types
 # 0x0a - file name
@@ -386,6 +387,7 @@ sub parseVariableEntry {
 #	  		my $sz = unpack("V",substr($stuff,$cnt,4));
 #	  		my $id = unpack("V",substr($stuff,$cnt + 4,4));
 #	  		
+#                        return %item unless (defined $sz); 
 #	  		if ($sz == 0x00) {
 #	  			$tag = 0;
 #	  			next;
@@ -652,6 +654,7 @@ sub parseFolderEntry {
 	my $str = "";
 	while($tag) {
 		my $s = substr($data,$ofs_shortname + $cnt,1);
+                return %item unless (defined $s); 
 		if ($s =~ m/\x00/ && ((($cnt + 1) % 2) == 0)) {
 			$tag = 0;
 		}
@@ -667,7 +670,9 @@ sub parseFolderEntry {
 	$tag = 1;
 	$cnt = 0;
 	while ($tag) {
-		if (unpack("v",substr($data,$ofs + $cnt,2)) == 0xbeef) {
+                my $s = substr($data,$ofs + $cnt,2);
+                return %item unless (defined $s); 
+		if (unpack("v",$s) == 0xbeef) {
 			$tag = 0;
 		}
 		else {

--- a/plugins/shellbags_xp.pl
+++ b/plugins/shellbags_xp.pl
@@ -397,7 +397,8 @@ sub parseVariableEntry {
 # 0x0e, 0x0f, 0x10 - mod date, create date, access date(?)
 # 0x0c - size
 #--------------------------------------------------------------	  	
-	  		if ($sz == 0x00) {
+                        return %item unless (defined $sz); 
+                        if ($sz == 0x00) {
 	  			$tag = 0;
 	  			next;
 	  		}
@@ -419,7 +420,7 @@ sub parseVariableEntry {
 #	  	while($tag) {
 #	  		my $sz = unpack("V",substr($stuff,$cnt,4));
 #	  		my $id = unpack("V",substr($stuff,$cnt + 4,4));
-#	  		
+#	  		return %item unless (defined $sz); 
 #	  		if ($sz == 0x00) {
 #	  			$tag = 0;
 #	  			next;
@@ -725,6 +726,7 @@ sub parseFolderEntry {
 	my $str = "";
 	while($tag) {
 		my $s = substr($data,$ofs_shortname + $cnt,1);
+                return %item unless (defined $s); 
 		if ($s =~ m/\x00/ && ((($cnt + 1) % 2) == 0)) {
 			$tag = 0;
 		}
@@ -740,7 +742,9 @@ sub parseFolderEntry {
 	$tag = 1;
 	$cnt = 0;
 	while ($tag) {
-		if (unpack("v",substr($data,$ofs + $cnt,2)) == 0xbeef) {
+                my $s = substr($data,$ofs + $cnt,2);
+                return %item unless (defined $s); 
+		if (unpack("v",$s) == 0xbeef) {
 			$tag = 0;
 		}
 		else {
@@ -829,7 +833,9 @@ sub parseFolderEntry2 {
 	my $tag = 1;
 
 	while ($tag) {
-		if (unpack("v",substr($data,$ofs,2)) == 0xbeef) {
+                my $s = substr($data,$ofs,2);
+                return %item unless (defined $s); 
+		if (unpack("v",$s) == 0xbeef) {
 			$tag = 0;
 		}
 		else {

--- a/plugins/shimcache.pl
+++ b/plugins/shimcache.pl
@@ -283,6 +283,7 @@ sub appWin8 {
 	
 	while($ofs < $len) {
 		my $tag = unpack("V",substr($data,$ofs,4));
+                last unless (defined $tag); 
 # 32-bit		
 		if ($tag == 0x73746f72) {
 			$jmp = unpack("V",substr($data,$ofs + 8,4));
@@ -327,6 +328,7 @@ sub appWin10 {
 	
 	while ($ofs < $len) {
 		$tag = substr($data,$ofs,4);
+                last unless (defined $tag); 
 		if ($tag eq "10ts") {
 			
 			$sz = unpack("V",substr($data,$ofs + 0x08,4));

--- a/plugins/shimcache_tln.pl
+++ b/plugins/shimcache_tln.pl
@@ -277,6 +277,7 @@ sub appWin8 {
 	
 	while($ofs < $len) {
 		my $tag = unpack("V",substr($data,$ofs,4));
+                last unless (defined $tag); 
 # 32-bit		
 		if ($tag == 0x73746f72) {
 			$jmp = unpack("V",substr($data,$ofs + 8,4));
@@ -321,6 +322,7 @@ sub appWin10 {
 	
 	while ($ofs < $len) {
 		$tag = substr($data,$ofs,4);
+                last unless (defined $tag); 
 		if ($tag eq "10ts") {
 			
 			$sz = unpack("V",substr($data,$ofs + 0x08,4));


### PR DESCRIPTION
All plugins modified so all loops that would previously only exit upon substr's results existing will now either cause their method to return or exit the loop in the case of non returning methods.  As another infinite loop was encountered when running on a ntuser.dat file this time in shellbags_xp.pl  