### PR TITLE
fix-getting-longfile-name-in-plugin-itempos

### DIFF
--- a/plugins/itempos.pl
+++ b/plugins/itempos.pl
@@ -1,6 +1,8 @@
 #-----------------------------------------------------------
 # itempos.pl
 # 
+# History:
+#   20191111 - Added default value to $jmp if $item{extver} cannot be determined.
 #
 # References
 #    http://c0nn3ct0r.blogspot.com/2011/11/windows-shellbag-forensics.html
@@ -264,7 +266,9 @@ sub parseFolderItem {
 	elsif ($item{extver} == 0x08) {
 		$jmp = 30;
 	}
-	else {}
+	else {
+        $jmp = 34;
+    }
 	
 	$ofs += $jmp;
 	


### PR DESCRIPTION
Updated itempos.pl plugin.  Fix getting long file name string.  If the extension verison was not a x03, x07 or x08 the start position was set to null to get the string so it would start at the beginning of the block so would get junk data.